### PR TITLE
Add device indicator top endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -50,7 +50,7 @@ async def create_device_event(request: Request, event: Event):
     return {"success": result}
 
 
-@app.get("/devices/histogram/{device_id}")
+@app.get("/devices/{device_id}/histogram")
 async def get_device_histogram(
     request: Request,
     device_id: str = Path(..., title="Device id", regex=DEVICE_ID_REGEX),

--- a/app/repository.py
+++ b/app/repository.py
@@ -17,15 +17,27 @@ async def add_event(credentials: dict, bucket: str, data: dict) -> bool:
     return result
 
 
-async def get_status_frequency(credentials: dict, query: str) -> list:
+async def get_status_frequency(
+    credentials: dict, bucket: str, device_id: str, start: str, stop: str
+) -> list:
     """Retrieve status frequency.
     Args:
         credentials (dict): dict containing database credentials.
-        query: (str): flux formatted query.
+        bucket (str): target bucket.
+        device_id (str): device id.
+        start (str): initial interval timestamp.
+        stop (str): final interval timestamp. Defaults to None.
     Returns:
         list: occurrences of each status.
     """
     frequency = []
+
+    query = f' from(bucket:"{bucket}")'
+    if stop:
+        query += f" |> range(start: {start}Z, stop: {stop}Z)"
+    else:
+        query += f" |> range(start: {start}Z)"
+    query += f' |> filter(fn:(r) => r.deviceId == "{device_id}")'
 
     async with InfluxDBClientAsync(**credentials) as client:
         query_api = client.query_api()

--- a/app/repository.py
+++ b/app/repository.py
@@ -38,6 +38,7 @@ async def get_status_frequency(
     else:
         query += f" |> range(start: {start}Z)"
     query += f' |> filter(fn:(r) => r.deviceId == "{device_id}")'
+    query += ' |> filter(fn:(r) => r._field == "status")'
 
     async with InfluxDBClientAsync(**credentials) as client:
         query_api = client.query_api()
@@ -48,3 +49,35 @@ async def get_status_frequency(
             frequency.append(value)
 
     return frequency
+
+
+async def get_top_n_records(
+    credentials: dict, bucket: str, device_id: str, indicator: str, limit: int
+) -> list:
+    """Get top n records.
+    Args:
+        credentials (dict): dict containing database credentials.
+        bucket (str): target bucket.
+        device_id (str): device id.
+        indicator (str): device indicator.
+        limit (int): limit for query records..
+    Returns:
+        list: top n ocurrences.
+    """
+    results = []
+
+    query = f' from(bucket:"{bucket}")'
+    query += " |> range(start: 0)"
+    query += f' |> filter(fn:(r) => r.deviceId == "{device_id}")'
+    query += f' |> filter(fn:(r) => r._field == "{indicator}")'
+    query += f" |> top(n: {limit})"
+
+    async with InfluxDBClientAsync(**credentials) as client:
+        query_api = client.query_api()
+        records = await query_api.query_stream(query)
+
+        async for record in records:
+            value = record.get_value()
+            results.append(value)
+
+    return results

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -17,14 +17,20 @@ class Event(BaseModel):
 
     device_id: str = Field(alias="deviceId")
     status: StatusEnum
+    temperature: float
     timestamp: str
+    pressure: float
 
     def data(self):
         """Return influxdb record compatible dict."""
         return {
             "measurement": "sensors",
             "tags": {"deviceId": self.device_id},
-            "fields": {"status": self.status},
+            "fields": {
+                "status": self.status,
+                "temperature": self.temperature,
+                "pressure": self.pressure,
+            },
             "time": self.timestamp,
         }
 

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -1,7 +1,7 @@
 from collections import Counter
 
 from .schemas import Event
-from .repository import add_event, get_status_frequency
+from .repository import add_event, get_status_frequency, get_top_n_records
 
 
 async def create_event(credentials: dict, bucket: str, event: Event) -> bool:
@@ -34,3 +34,20 @@ async def get_histogram(
     frequency = await get_status_frequency(credentials, bucket, device_id, start, stop)
     histogram = Counter(frequency)
     return histogram
+
+
+async def get_indicator_top_n_records(
+    credentials: dict, bucket: str, device_id: str, indicator: str, limit: int
+) -> tuple:
+    """Get indicator top n records.
+    Args:
+        credentials (dict): dict containing database credentials.
+        bucket (str): target bucket.
+        device_id (str): device id.
+        indicator (str): device indicator.
+        limit (int): limit for db query.
+    Returns:
+        list: top n ocurrences.
+    """
+    records = await get_top_n_records(credentials, bucket, device_id, indicator, limit)
+    return records

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -2,7 +2,6 @@ from collections import Counter
 
 from .schemas import Event
 from .repository import add_event, get_status_frequency
-from .utils import get_formatted_flux_query
 
 
 async def create_event(credentials: dict, bucket: str, event: Event) -> bool:
@@ -20,18 +19,18 @@ async def create_event(credentials: dict, bucket: str, event: Event) -> bool:
 
 
 async def get_histogram(
-    credentials: dict, bucket: str, query_parameters: dict
+    credentials: dict, bucket: str, device_id: str, start: str, stop: str | None
 ) -> tuple:
     """Get device histogram.
     Args:
         credentials (dict): dict containing database credentials.
         bucket (str): target bucket.
-        query_parameters (dict): query parameters.
+        device_id (str): device id.
+        start (str): initial interval timestamp.
+        stop (str): final interval timestamp. Defaults to None.
     Returns:
         dict: histogram (x=key, y=value).
     """
-    query = get_formatted_flux_query(bucket, query_parameters)
-    frequency = await get_status_frequency(credentials, query)
-
+    frequency = await get_status_frequency(credentials, bucket, device_id, start, stop)
     histogram = Counter(frequency)
     return histogram

--- a/app/utils.py
+++ b/app/utils.py
@@ -46,37 +46,3 @@ def get_db_credentials(env_vars: dict) -> dict:
         "token": env_vars["DOCKER_INFLUXDB_INIT_ADMIN_TOKEN"],
         "org": env_vars["DOCKER_INFLUXDB_INIT_ORG"],
     }
-
-
-def get_query_parameters(device_id: str, start: str, stop: str) -> dict:
-    """Retrieves query parameters.
-    Args:
-        device_id (str): target device id.
-        start: (str) start range timestamp.
-        stop: (str) end (stop at) range timestamp.
-    Returns:
-        dict: dictionary containing query parameters.
-    """
-    return {"deviceId": device_id, "start": start, "stop": stop}
-
-
-def get_formatted_flux_query(bucket, query_parameters: dict) -> str:
-    """Retrieves query parameters.
-    Args:
-        bucket (str): target bucket.
-        query_parameters (dict): query parameters.
-    Returns:
-        str: formatted flux query.
-    """
-    device_id = query_parameters["deviceId"]
-    start = query_parameters["start"]
-    stop = query_parameters.get("stop")
-
-    query = f' from(bucket:"{bucket}")'
-    if stop:
-        query += f" |> range(start: {start}Z, stop: {stop}Z)"
-    else:
-        query += f" |> range(start: {start}Z)"
-    query += f' |> filter(fn:(r) => r.deviceId == "{device_id}")'
-
-    return query

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -15,7 +15,13 @@ def bucket():
 
 @pytest.fixture
 def event():
-    return Event(deviceId="sensor-1", status="ON", timestamp="2020-01-02T03:44:02")
+    return Event(
+        deviceId="sensor-1",
+        status="ON",
+        temperature=230,
+        timestamp="2020-01-02T03:44:02",
+        pressure=212.0,
+    )
 
 
 @pytest.fixture

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -34,15 +34,6 @@ def device_id():
 
 
 @pytest.fixture
-def query_parameters():
-    return {
-        "deviceId": "sensor-1",
-        "start": "2020-01-02T03:44:00",
-        "stop": "2020-01-02T03:48:00",
-    }
-
-
-@pytest.fixture
 def qs(start, stop):
     return f"start={start}&stop={stop}"
 
@@ -60,6 +51,7 @@ def env_vars():
         "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN": "mocked_token",
         "DOCKER_INFLUXDB_INIT_ORG": "mocked_org",
     }
+
 
 @pytest.fixture
 def event_request_payload():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,11 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 from .fixtures import (
-    device_id, start, stop, event_request_payload, histogram_response_payload
+    device_id,
+    start,
+    stop,
+    event_request_payload,
+    histogram_response_payload,
 )
 from .base import AsyncMock
 
@@ -29,10 +33,7 @@ async def test_health(mocked_ping):
 async def test_create_event(mocked_create_event, event_request_payload):
     mocked_create_event.return_value = True
 
-    response = client.post(
-        "/devices/events",
-        json=event_request_payload
-    )
+    response = client.post("/devices/events", json=event_request_payload)
     assert response.status_code == HTTPStatus.CREATED
     assert response.json() == {"success": True}
 
@@ -40,10 +41,10 @@ async def test_create_event(mocked_create_event, event_request_payload):
 @pytest.mark.asyncio
 @patch("app.main.get_histogram", new_callable=AsyncMock)
 async def test_get_device_histogram(
-        mocked_get_histogram, device_id, start, stop, histogram_response_payload
-    ):
+    mocked_get_histogram, device_id, start, stop, histogram_response_payload
+):
     mocked_get_histogram.return_value = histogram_response_payload
 
     qs = f"start={start}&stop={stop}"
-    response = client.get(f"/devices/histogram/{device_id}?{qs}")
+    response = client.get(f"/devices/{device_id}/histogram?{qs}")
     assert response.json() == histogram_response_payload

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -5,8 +5,14 @@ from unittest.mock import patch
 import pytest
 
 from app.use_cases import create_event, get_histogram
-from app.utils import get_formatted_flux_query
-from .fixtures import db_credentials, bucket, event, query_parameters, frequency
+from .fixtures import (
+    db_credentials, bucket,
+    device_id,
+    start,
+    stop,
+    event,
+    frequency
+)
 from .base import AsyncMock
 
 
@@ -23,12 +29,17 @@ async def test_create_event(mocked_add_event, db_credentials, bucket, event):
 @pytest.mark.asyncio
 @patch("app.use_cases.get_status_frequency", new_callable=AsyncMock)
 async def test_get_histogram(
-    mocked_get_status_frequency, db_credentials, bucket, query_parameters, frequency
+    mocked_get_status_frequency,
+    frequency, db_credentials,
+    bucket,
+    device_id,
+    start,
+    stop
 ):
     mocked_get_status_frequency.return_value = frequency
 
-    res = await get_histogram(db_credentials, bucket, query_parameters)
+    res = await get_histogram(db_credentials, bucket, device_id, start, stop)
     mocked_get_status_frequency.assert_called_once_with(
-        db_credentials, get_formatted_flux_query(bucket, query_parameters)
+        db_credentials, bucket, device_id, start, stop
     )
     assert res == Counter(frequency)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,11 +7,9 @@ from app.utils import (
     load_environment_variable,
     get_environment_variables,
     get_db_credentials,
-    get_query_parameters,
-    get_formatted_flux_query,
 )
 
-from .fixtures import env_vars, query_parameters, bucket, device_id, start, stop
+from .fixtures import env_vars, bucket, device_id, start, stop
 
 
 def test_load_environment_variable():
@@ -42,33 +40,4 @@ def test_get_db_credentials(env_vars):
     assert ret["token"] == env_vars["DOCKER_INFLUXDB_INIT_ADMIN_TOKEN"]
     assert (
         ret["url"] == f"http://{env_vars['INFLUXDB_HOST']}:{env_vars['INFLUXDB_PORT']}"
-    )
-
-
-def test_get_query_parameters(device_id, start, stop):
-    ret = get_query_parameters(device_id, start, stop)
-
-    assert ret["deviceId"] == device_id
-    assert ret["start"] == start
-    assert ret["stop"] == stop
-
-
-def test_get_formatted_flux_query(bucket, query_parameters):
-    ret = get_formatted_flux_query(bucket, query_parameters)
-
-    assert ret == (
-        f' from(bucket:"{bucket}")'
-        f' |> range(start: {query_parameters["start"]}Z, stop: {query_parameters["stop"]}Z)'
-        f' |> filter(fn:(r) => r.deviceId == "{query_parameters["deviceId"]}")'
-    )
-
-
-def test_get_formatted_flux_query_without_stop(bucket, query_parameters):
-    query_parameters.pop("stop")
-    ret = get_formatted_flux_query(bucket, query_parameters)
-
-    assert ret == (
-        f' from(bucket:"{bucket}")'
-        f' |> range(start: {query_parameters["start"]}Z)'
-        f' |> filter(fn:(r) => r.deviceId == "{query_parameters["deviceId"]}")'
     )


### PR DESCRIPTION
### Changes
- Add view `device_top_n_records`;
- Add use case for  `device_indicator_top_n_records`;
- Add repository  for  `indicator_top_n_records`;
- Update simulator to generate random values for all indicators;
- Update histogram view url to `devices/:device_id/histogram`;
- Remove query formatting helpers (the logic was moved to the repositories);
- Update histogram query to retrieve only the status field.